### PR TITLE
Switched from DiffMarkupFormatter.Instance to new() to avoid thread safety issues

### DIFF
--- a/src/Verify.Bunit/MarkupFormattableConverter.cs
+++ b/src/Verify.Bunit/MarkupFormattableConverter.cs
@@ -7,7 +7,7 @@
         writer.WriteMember(
             markup,
             markup
-            .ToHtml(DiffMarkupFormatter.Instance)
+            .ToHtml(new DiffMarkupFormatter())
             .Trim(),
             "Markup");
         writer.WriteEndObject();

--- a/src/Verify.Bunit/MarkupFormattableToString.cs
+++ b/src/Verify.Bunit/MarkupFormattableToString.cs
@@ -5,6 +5,6 @@
             null,
             "html",
             markup
-                .ToHtml(DiffMarkupFormatter.Instance)
+                .ToHtml(new DiffMarkupFormatter())
                 .Trim());
 }

--- a/src/Verify.Bunit/RenderedFragmentConverter.cs
+++ b/src/Verify.Bunit/RenderedFragmentConverter.cs
@@ -14,7 +14,7 @@ class RenderedFragmentConverter :
         writer.WriteMember(
             fragment,
             fragment
-            .Nodes.ToHtml(DiffMarkupFormatter.Instance)
+            .Nodes.ToHtml(new DiffMarkupFormatter())
             .Trim(),
             "Markup");
         writer.WriteEndObject();

--- a/src/Verify.Bunit/RenderedFragmentMarkupToString.cs
+++ b/src/Verify.Bunit/RenderedFragmentMarkupToString.cs
@@ -3,7 +3,7 @@ static class RenderedFragmentMarkupToString
     public static ConversionResult Convert(IRenderedFragment fragment, IReadOnlyDictionary<string, object> context)
     {
         var markup = fragment
-            .Nodes.ToHtml(DiffMarkupFormatter.Instance)
+            .Nodes.ToHtml(new DiffMarkupFormatter())
             .Trim();
         return new(null, "html", markup);
     }

--- a/src/Verify.Bunit/RenderedFragmentToString.cs
+++ b/src/Verify.Bunit/RenderedFragmentToString.cs
@@ -4,7 +4,7 @@ static class RenderedFragmentToString
     {
         var nodes = fragment.Nodes;
         var markup = nodes
-            .ToHtml(DiffMarkupFormatter.Instance)
+            .ToHtml(new DiffMarkupFormatter())
             .Trim();
         var nodeCount = nodes.Sum(_ => _
             .GetDescendantsAndSelf()


### PR DESCRIPTION
Relates to Issue #60   and that DiffMarupFormatter is not thread safe, so running tests in parallel causes issues with trying to indent a negative number of spaces (in Bunit code).