### PR TITLE
Fix NullReferenceException comparing markup with style attributes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Enable at startup:
 public static void Initialize() =>
     VerifyBunit.Initialize();
 ```
-<sup><a href='/src/Tests/ModuleInitializer.cs#L5-L11' title='Snippet source file'>snippet source</a> | <a href='#snippet-BunitEnable' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/ModuleInitializer.cs#L3-L9' title='Snippet source file'>snippet source</a> | <a href='#snippet-BunitEnable' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This test:
@@ -245,7 +245,7 @@ VerifierSettings.ScrubLinesWithReplace(
 HtmlPrettyPrint.All();
 VerifierSettings.ScrubLinesContaining("<script src=\"_framework/dotnet.");
 ```
-<sup><a href='/src/Tests/ModuleInitializer.cs#L16-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrubbers' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/ModuleInitializer.cs#L14-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrubbers' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;BL0006;NU1608;NU1109</NoWarn>
-    <Version>13.0.4-beta.1</Version>
+    <Version>13.0.4</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/src/Tests/HtmlComparerTests.StyledElement_SemanticallyEqual.verified.html
+++ b/src/Tests/HtmlComparerTests.StyledElement_SemanticallyEqual.verified.html
@@ -1,0 +1,1 @@
+<div style="color: red; font-size: 10pt">text</div>

--- a/src/Tests/HtmlComparerTests.cs
+++ b/src/Tests/HtmlComparerTests.cs
@@ -1,0 +1,13 @@
+public class HtmlComparerTests
+{
+    // Regression for a NullReferenceException in AngleSharp.Diffing's StyleAttributeComparer. This style
+    // attribute differs from the verified file's only in whitespace and a trailing semicolon, so the two
+    // markup strings are not byte-equal and the html comparer parses and compares them. It used to throw
+    // because the parser had no CSS support, leaving each element's inline style null; the styles must now
+    // compare as semantically equal. The two spellings are deliberately different — keep them that way.
+    [Fact]
+    public Task StyledElement_SemanticallyEqual() =>
+        Verify(
+            "<div style=\"color:red;font-size:10pt;\">text</div>",
+            extension: "html");
+}

--- a/src/Tests/ModuleInitializer.cs
+++ b/src/Tests/ModuleInitializer.cs
@@ -1,6 +1,4 @@
-﻿using VerifyTests.DiffPlex;
-
-public static class ModuleInitializer
+﻿public static class ModuleInitializer
 {
     #region BunitEnable
 

--- a/src/Verify.Bunit/BunitMarkupComparer.cs
+++ b/src/Verify.Bunit/BunitMarkupComparer.cs
@@ -4,9 +4,16 @@ using CompareResult = VerifyTests.CompareResult;
 
 static class BunitMarkupComparer
 {
+    // AngleSharp.Diffing compares style attributes semantically, which needs the parsed markup to carry
+    // a real CSS object model. A default HtmlParser has no CSS support, so an element's inline style
+    // parses to null and StyleAttributeComparer throws a NullReferenceException the moment two style
+    // attributes differ. Parsing through a CSS-enabled configuration gives every element a real
+    // ICssStyleDeclaration, so the style comparison works.
+    static readonly IConfiguration configuration = Configuration.Default.WithCss();
+
     public static Task<CompareResult> Compare(string received, string verified, IReadOnlyDictionary<string, object> context)
     {
-        var parser = new HtmlParser();
+        var parser = new HtmlParser(new(), BrowsingContext.New(configuration));
         var receivedDoc = parser.ParseDocument(received);
         var verifiedDoc = parser.ParseDocument(verified);
         var diffs = receivedDoc.Body!.ChildNodes.CompareTo(verifiedDoc.Body!.ChildNodes);


### PR DESCRIPTION
Fix NullReferenceException comparing markup with style attributes

BunitMarkupComparer parsed markup with a CSS-unaware HtmlParser, so an element's inline style parsed to a null ICssStyleDeclaration. AngleSharp .Diffing's StyleAttributeComparer compares style attributes semantically, so it dereferenced that null and threw the moment two style attributes differed — surfacing as an NRE instead of a diff on any HTML snapshot whose elements carry differing styles.

Parse through a CSS-enabled configuration (Configuration.Default.WithCss()) so every element gets a real CSS object model and the style comparison works. AngleSharp.Css is already present transitively via bunit.

Add a regression test covering two markup strings that differ only in style-attribute whitespace, which forces the comparer through the CSS parse that previously crashed.